### PR TITLE
Construct log entry only when needed.

### DIFF
--- a/src/main/java/org/jdbcdslog/PreparedStatementLoggingHandler.java
+++ b/src/main/java/org/jdbcdslog/PreparedStatementLoggingHandler.java
@@ -41,20 +41,23 @@ public class PreparedStatementLoggingHandler implements InvocationHandler {
                 parameters = new TreeMap();
 
             if (toLog) {
-                // StringBuffer sb = LogUtils.createLogEntry(method, sql, parametersToString(), null);
-                StringBuffer sb = LogUtils.createLogEntry(sql, parameters);
 
                 long t2 = System.nanoTime();
                 long time = t2 - t1;
-                if (ConfigurationParameters.showTime) {
-                    BigDecimal t = (new BigDecimal(t2)).subtract(new BigDecimal(t1)).divide(new BigDecimal(1000000000));
-                    sb.append(" ").append(t).append(" s.");
-                }
 
-                StatementLogger.info(sb.toString());
+                if (StatementLogger.isInfoEnabled() || time >= ConfigurationParameters.slowQueryThreshold) {
+                    StringBuffer sb = LogUtils.createLogEntry(sql, parameters);
 
-                if (time >= ConfigurationParameters.slowQueryThreshold) {
-                    SlowQueryLogger.info(sb.toString());
+                    if (ConfigurationParameters.showTime) {
+                        BigDecimal t = (new BigDecimal(t2)).subtract(new BigDecimal(t1)).divide(new BigDecimal(1000000000));
+                        sb.append(" ").append(t).append(" s.");
+                    }
+
+                    StatementLogger.info(sb.toString());
+
+                    if (time >= ConfigurationParameters.slowQueryThreshold) {
+                        SlowQueryLogger.info(sb.toString());
+                    }
                 }
             }
             if (r instanceof ResultSet)


### PR DESCRIPTION
Remove exhausted creating LogEntry in case of StatementLogger is switched off .